### PR TITLE
WIP Optional workflow params

### DIFF
--- a/lib/galaxy/tools/parser/yaml.py
+++ b/lib/galaxy/tools/parser/yaml.py
@@ -30,7 +30,7 @@ class YamlToolSource(ToolSource):
         return self.root_dict.get("name")
 
     def parse_description(self):
-        return self.root_dict.get("description")
+        return self.root_dict.get("description", "")
 
     def parse_is_multi_byte(self):
         return self.root_dict.get("is_multi_byte", self.default_is_multi_byte)

--- a/test/functional/tools/optional_params.xml
+++ b/test/functional/tools/optional_params.xml
@@ -6,8 +6,8 @@
     </command>
     <inputs>
         <param name="input" type="data" label="Input" />
-        <param name="inttest" value="1" type="integer" optional="True" />
-        <param name="floattest" value="1.0" type="float" optional="True" />
+        <param name="inttest" type="integer" optional="True" />
+        <param name="floattest" min="0" max="1" type="float" optional="True" />
     </inputs>
     <outputs>
         <data name="out_file1" format="txt" />


### PR DESCRIPTION
This PR reproduces the behaviour reported in issue galaxy/galaxyproject#1721. Tools with a float param that contains max=/min= but no value= attributes crashes execution of a workflow on a validation step.