### PR TITLE
Speed up dependency view

### DIFF
--- a/lib/galaxy/tool_util/deps/views.py
+++ b/lib/galaxy/tool_util/deps/views.py
@@ -238,9 +238,10 @@ class DependencyResolversView(object):
         if 'install' in kwds:
             summary_kwds['install'] = asbool(kwds['install'])
 
+        tool_ids_by_requirements = self.tool_ids_by_requirements
         statuses = {r: self.get_requirements_status(tool_requirements_d={tids[0]: r},
                                                 installed_tool_dependencies=self._app.toolbox.tools_by_id[tids[0]].installed_tool_dependencies, **summary_kwds)
-                for r, tids in self.tool_ids_by_requirements.items()}
+                for r, tids in tool_ids_by_requirements.items()}
         if kwds.get("for_json", False):
             # All public attributes of this class should be returning JSON - this is meant to mimic a restful API.
             rval = []
@@ -248,7 +249,7 @@ class DependencyResolversView(object):
                 item = {}
                 item["requirements"] = requirements.to_dict()
                 item["status"] = status
-                item["tool_ids"] = self.tool_ids_by_requirements[requirements]
+                item["tool_ids"] = tool_ids_by_requirements[requirements]
                 rval.append(item)
             statuses = rval
         return statuses


### PR DESCRIPTION
Profiling before:
```
*** PROFILER RESULTS ***
summarize_toolbox (/Users/mvandenb/src/galaxy/lib/galaxy/web/framework/decorators.py:228)
function called 1 times

         42850785 function calls (40691205 primitive calls) in 63.276 seconds

   Ordered by: cumulative time, internal time, call count
   List reduced from 279 to 40 due to restriction <40>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   63.276   63.276 decorators.py:228(decorator)
        1    0.000    0.000   63.272   63.272 decorators.py:87(decorator)
        1    0.000    0.000   63.272   63.272 tool_dependencies.py:189(summarize_toolbox)
        1    0.056    0.056   63.272   63.272 views.py:228(summarize_requirements)
      277    7.137    0.026   61.665    0.223 views.py:211(tool_ids_by_requirements)
   716598    2.004    0.000   26.227    0.000 requirements.py:127(__eq__)
  1586883    3.859    0.000   24.838    0.000 oset.py:8(__init__)
  1428437    5.199    0.000   20.979    0.000 _collections_abc.py:604(__ior__)
   869226    1.421    0.000   20.939    0.000 __init__.py:1664(tool_requirements)
   716598    1.772    0.000   20.415    0.000 _collections_abc.py:474(__and__)
   869226    3.086    0.000   19.518    0.000 requirements.py:115(packages)
   716598    1.240    0.000   16.914    0.000 _collections_abc.py:465(_from_iterable)
   870285    2.999    0.000   12.723    0.000 requirements.py:99(__init__)
  1677185    5.694    0.000    8.816    0.000 oset.py:21(add)
   869778    1.800    0.000    7.336    0.000 requirements.py:143(__hash__)
  1413485    3.166    0.000    6.964    0.000 _collections_abc.py:477(<genexpr>)
   869778    3.816    0.000    5.332    0.000 requirements.py:144(<listcomp>)
  5052459    4.203    0.000    4.730    0.000 requirements.py:51(__hash__)
4321842/2163046    3.081    0.000    3.828    0.000 {built-in method builtins.len}
   869226    2.847    0.000    3.734    0.000 requirements.py:117(<listcomp>)
   696887    2.075    0.000    3.291    0.000 oset.py:18(__contains__)
  5151455    2.050    0.000    2.050    0.000 oset.py:33(__iter__)
  2456292    1.339    0.000    1.918    0.000 {built-in method builtins.isinstance}
        1    0.008    0.008    1.531    1.531 views.py:241(<dictcomp>)
      276    0.023    0.000    1.496    0.005 views.py:282(get_requirements_status)
      276    0.007    0.000    1.436    0.005 views.py:52(show_dependencies)
      276    0.007    0.000    1.428    0.005 views.py:62(<dictcomp>)
      276    0.002    0.000    1.420    0.005 __init__.py:185(requirements_to_dependencies)
      276    0.083    0.000    1.418    0.005 __init__.py:198(_requirements_to_dependencies_dict)
  2154295    0.745    0.000    0.927    0.000 oset.py:15(__len__)
     2457    0.016    0.000    0.736    0.000 __init__.py:1356(debug)
     2457    0.022    0.000    0.719    0.000 __init__.py:1491(_log)
   723361    0.247    0.000    0.579    0.000 abc.py:137(__instancecheck__)
     2457    0.011    0.000    0.577    0.000 __init__.py:1516(handle)
     2457    0.011    0.000    0.565    0.000 __init__.py:1570(callHandlers)
     2457    0.018    0.000    0.554    0.000 __init__.py:881(handle)
  5052459    0.527    0.000    0.527    0.000 {built-in method builtins.hash}
     2457    0.017    0.000    0.523    0.000 __init__.py:1013(emit)
   696378    0.495    0.000    0.495    0.000 requirements.py:45(__eq__)
   711839    0.398    0.000    0.481    0.000 requirements.py:103(<listcomp>)
```

Profiling after:
```
*** PROFILER RESULTS ***
summarize_toolbox (/Users/mvandenb/src/galaxy/lib/galaxy/web/framework/decorators.py:228)
function called 1 times

         725248 function calls (707704 primitive calls) in 1.945 seconds

   Ordered by: cumulative time, internal time, call count
   List reduced from 278 to 40 due to restriction <40>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    1.945    1.945 decorators.py:228(decorator)
        1    0.000    0.000    1.941    1.941 decorators.py:87(decorator)
        1    0.000    0.000    1.941    1.941 tool_dependencies.py:189(summarize_toolbox)
        1    0.005    0.005    1.941    1.941 views.py:228(summarize_requirements)
        1    0.008    0.008    1.708    1.708 views.py:242(<dictcomp>)
      276    0.025    0.000    1.672    0.006 views.py:283(get_requirements_status)
      276    0.008    0.000    1.607    0.006 views.py:52(show_dependencies)
      276    0.008    0.000    1.599    0.006 views.py:62(<dictcomp>)
      276    0.002    0.000    1.590    0.006 __init__.py:185(requirements_to_dependencies)
      276    0.089    0.000    1.589    0.006 __init__.py:198(_requirements_to_dependencies_dict)
     2457    0.018    0.000    0.818    0.000 __init__.py:1356(debug)
     2457    0.025    0.000    0.798    0.000 __init__.py:1491(_log)
     2457    0.012    0.000    0.643    0.000 __init__.py:1516(handle)
     2457    0.011    0.000    0.630    0.000 __init__.py:1570(callHandlers)
     2457    0.019    0.000    0.619    0.000 __init__.py:881(handle)
     2457    0.018    0.000    0.586    0.000 __init__.py:1013(emit)
     2457    0.021    0.000    0.456    0.000 pydevd_io.py:30(write)
     4198    0.265    0.000    0.265    0.000 {built-in method posix.stat}
     2457    0.024    0.000    0.243    0.000 pydevd.py:2044(write)
        1    0.026    0.026    0.220    0.220 views.py:211(tool_ids_by_requirements)
     1483    0.008    0.000    0.200    0.000 galaxy_packages.py:68(resolve)
      961    0.023    0.000    0.192    0.000 conda.py:256(resolve)
     2457    0.190    0.000    0.190    0.000 {method 'write' of '_io.TextIOWrapper' objects}
     2936    0.006    0.000    0.175    0.000 genericpath.py:39(isdir)
      507    0.016    0.000    0.171    0.000 conda.py:184(resolve_all)
     2457    0.029    0.000    0.163    0.000 pydevd_net_command_factory_json.py:248(make_io_message)
      974    0.006    0.000    0.149    0.000 galaxy_packages.py:112(resolve)
      631    0.010    0.000    0.117    0.000 galaxy_packages.py:96(_galaxy_package_dep)
     2457    0.035    0.000    0.114    0.000 pydevd_net_command.py:36(__init__)
     6783    0.018    0.000    0.108    0.000 oset.py:8(__init__)
     2457    0.012    0.000    0.106    0.000 __init__.py:1476(makeRecord)
     1262    0.003    0.000    0.099    0.000 genericpath.py:16(exists)
     2586    0.007    0.000    0.094    0.000 requirements.py:127(__eq__)
     2457    0.056    0.000    0.094    0.000 __init__.py:282(__init__)
     1468    0.006    0.000    0.092    0.000 conda_util.py:318(has_env)
     6209    0.023    0.000    0.090    0.000 _collections_abc.py:604(__ior__)
      503    0.003    0.000    0.088    0.000 galaxy_packages.py:81(_find_dep_versioned)
     2457    0.006    0.000    0.077    0.000 __init__.py:858(format)
     3138    0.005    0.000    0.074    0.000 __init__.py:1664(tool_requirements)
     2586    0.006    0.000    0.073    0.000 _collections_abc.py:474(__and__)
```