### PR TITLE
Implement access_id method to fetch via /object/{id}/access/{access_id}.

### DIFF
--- a/lib/galaxy/util/drs.py
+++ b/lib/galaxy/util/drs.py
@@ -3,12 +3,10 @@ from typing import Union
 
 import requests
 
-#from galaxy.util import (
-#    CHUNK_SIZE,
-#    DEFAULT_SOCKET_TIMEOUT,
-#)
-CHUNK_SIZE=2048
-DEFAULT_SOCKET_TIMEOUT=60
+from galaxy.util import (
+    CHUNK_SIZE,
+    DEFAULT_SOCKET_TIMEOUT,
+)
 
 TargetPathT = Union[str, PathLike]
 


### PR DESCRIPTION
This implements the access_id method in DRS, as per: https://ga4gh.github.io/data-repository-service-schemas/preview/develop/docs/#tag/Service-Info/operation/GetServiceInfo
at least one of access_url or access_id should be represented. Some argue that either should be the case https://github.com/ga4gh/data-repository-service-schemas/issues/360 
whatever the final resolution will be on the ticket - In the absence of access_url using the access endpoint is definitely up to spec ;).

KR,
Uwe

(If fixing a bug, please add any relevant error or traceback)
(For UI components, it is recommended to include screenshots or screencasts)

## How to test the changes?
(Select all options that apply)
- [ ] I've included appropriate [automated tests](https://docs.galaxyproject.org/en/latest/dev/writing_tests.html).
- [ ] This is a refactoring of components with existing test coverage.
- [x] Instructions for manual testing are as follows:
use any DRS wich uses access_id (I have my own little not yet public one).

## License
- [x] I agree to license these contributions under [Galaxy's current license](https://github.com/galaxyproject/galaxy/blob/dev/LICENSE.txt).
- [x] I agree to allow the Galaxy committers to license these and all my past contributions to the core galaxy codebase under the [MIT license](https://opensource.org/licenses/MIT). If this condition is an issue, uncheck and just let us know why with an e-mail to galaxy-committers@lists.galaxyproject.org.
